### PR TITLE
SP-713 Remove '_m' from image URLs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ const createWalletCurrency = (currency) => {
   currencyWrapper.classList.add(...currencyWrapperClassLists);
   currencyCode.textContent = currency.code;
   currencyCode.classList.add(...currencyCodeClassLists);
-  currencyImage.src = currency.image;
+  currencyImage.src = currency.image.replace('_m', '');
   currencyImage.classList.add(...currencyImageClassLists);
   currencyWrapper.appendChild(currencyImage);
   currencyWrapper.appendChild(currencyCode);


### PR DESCRIPTION
The API generates the `image` field dynamically based on the `code` field, but there aren't currently images with `_m` on the end. The icons will be the same as their counterparts without `_m`, so we can safely remove it until they have their own images.